### PR TITLE
IP-2525: Fix album picker button

### DIFF
--- a/Pod/Assets/AlbumTitleView.xib
+++ b/Pod/Assets/AlbumTitleView.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AlbumTitleView" customModule="BSImagePicker"/>
@@ -14,15 +18,17 @@
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XBJ-wa-q8C">
                     <rect key="frame" x="8" y="0.0" width="584" height="30"/>
                     <state key="normal" title="Button">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                 </button>
             </subviews>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstAttribute="bottom" secondItem="XBJ-wa-q8C" secondAttribute="bottom" id="G7Y-oO-hg1"/>
                 <constraint firstAttribute="centerY" secondItem="XBJ-wa-q8C" secondAttribute="centerY" id="VNW-U1-5lq"/>
                 <constraint firstItem="XBJ-wa-q8C" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="8" id="Xu8-zz-8Vo"/>
                 <constraint firstAttribute="trailing" secondItem="XBJ-wa-q8C" secondAttribute="trailing" constant="8" id="je3-VY-t8h"/>
+                <constraint firstItem="XBJ-wa-q8C" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="rxZ-Et-FbG"/>
                 <constraint firstAttribute="centerX" secondItem="XBJ-wa-q8C" secondAttribute="centerX" id="yGE-8Z-sir"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>


### PR DESCRIPTION
On iOS 11, the button had zero height inside the navigation item's custom title view. This adds top and bottom constraints from the button to the custom title view. Verified on iOS 10 and iOS 11 simulators.